### PR TITLE
[FEAT] Controller 계층 구현

### DIFF
--- a/graphQL/src/main/kotlin/com/sopt/team1/common/RequestHeaderInterceptor.kt
+++ b/graphQL/src/main/kotlin/com/sopt/team1/common/RequestHeaderInterceptor.kt
@@ -1,0 +1,18 @@
+package com.sopt.team1.common
+
+import org.springframework.graphql.server.WebGraphQlInterceptor
+import org.springframework.graphql.server.WebGraphQlRequest
+import org.springframework.graphql.server.WebGraphQlResponse
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class RequestHeaderInterceptor : WebGraphQlInterceptor {
+    override fun intercept(request: WebGraphQlRequest, chain: WebGraphQlInterceptor.Chain): Mono<WebGraphQlResponse> {
+        val value = request.headers.getFirst("user-id")
+        request.configureExecutionInput { executionInput, builder ->
+            builder.graphQLContext(mapOf("user-id" to value)).build()
+        }
+        return chain.next(request)
+    }
+}

--- a/graphQL/src/main/kotlin/com/sopt/team1/controller/FollowController.kt
+++ b/graphQL/src/main/kotlin/com/sopt/team1/controller/FollowController.kt
@@ -1,0 +1,22 @@
+package com.sopt.team1.controller
+
+import com.sopt.team1.controller.dto.FollowResponseDTO
+import com.sopt.team1.service.FollowService
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.stereotype.Controller
+
+@Controller
+class FollowController(
+    private val followService: FollowService
+) {
+    @MutationMapping
+    fun followUser(@Argument followerId: Long, @Argument followingId: Long): FollowResponseDTO {
+        return followService.follow(followerId, followingId)
+    }
+
+    @MutationMapping
+    fun unfollowUser(@Argument followerId: Long, @Argument followingId: Long): FollowResponseDTO {
+        return followService.unfollow(followerId, followingId)
+    }
+}

--- a/graphQL/src/main/kotlin/com/sopt/team1/controller/FollowController.kt
+++ b/graphQL/src/main/kotlin/com/sopt/team1/controller/FollowController.kt
@@ -2,21 +2,25 @@ package com.sopt.team1.controller
 
 import com.sopt.team1.controller.dto.FollowResponseDTO
 import com.sopt.team1.service.FollowService
+import graphql.GraphQLContext
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.MutationMapping
 import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestHeader
 
 @Controller
 class FollowController(
     private val followService: FollowService
 ) {
     @MutationMapping
-    fun followUser(@Argument followerId: Long, @Argument followingId: Long): FollowResponseDTO {
+    fun followUser(context: GraphQLContext, @Argument followingId: Long): FollowResponseDTO {
+        val followerId = context.get<String>("user-id").toLong()
         return followService.follow(followerId, followingId)
     }
 
     @MutationMapping
-    fun unfollowUser(@Argument followerId: Long, @Argument followingId: Long): FollowResponseDTO {
+    fun unfollowUser(context: GraphQLContext, @Argument followingId: Long): FollowResponseDTO {
+        val followerId = context.get<String>("user-id").toLong()
         return followService.unfollow(followerId, followingId)
     }
 }

--- a/graphQL/src/main/resources/graphql/schema.graphqls
+++ b/graphQL/src/main/resources/graphql/schema.graphqls
@@ -16,8 +16,8 @@ type Follow {
 
 type FollowResponseDTO{
     id: ID!
-    following: Int!
-    follower: Int!
+    followingCount: Int!
+    followerCount: Int!
 }
 
 type Query {

--- a/graphQL/src/main/resources/graphql/schema.graphqls
+++ b/graphQL/src/main/resources/graphql/schema.graphqls
@@ -25,6 +25,6 @@ type Query {
 }
 
 type Mutation {
-    followUser(followerId: ID!, followingId: ID!): FollowResponseDTO!
-    unfollowUser(followerId: ID!, followingId: ID!): FollowResponseDTO!
+    followUser(followingId: ID!): FollowResponseDTO!
+    unfollowUser(followingId: ID!): FollowResponseDTO!
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#5 -> main
- closed #5


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- controller 계층을 구현했습니다
- follow/unfollow 행위를 하는 유저의 id는 헤더값으로 전달받도록 구현했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/Graphql-Team1/team1-server/assets/81363864/df06fc95-5d14-4419-8ad2-a2b426a832c7)

