### PR TITLE
[FIX] 응답값을 팔로우 하는 유저가 아닌 팔로잉하는 유저의 정보를 반환하도록 수정

### DIFF
--- a/graphQL/src/main/kotlin/com/sopt/team1/service/FollowService.kt
+++ b/graphQL/src/main/kotlin/com/sopt/team1/service/FollowService.kt
@@ -28,9 +28,9 @@ class FollowService(private val followRepository: FollowRepository, private val 
                 target.follower += 1
 
                 return FollowResponseDTO(
-                    id = follower.id ?: error("Follower id should not be null"),
-                    followerCount = follower.follower,
-                    followingCount = follower.following
+                    id = target.id ?: error("Target id should not be null"),
+                    followerCount = target.follower,
+                    followingCount = target.following
                 )
             }
         }
@@ -53,9 +53,9 @@ class FollowService(private val followRepository: FollowRepository, private val 
                 target.follower -= 1
 
                 return FollowResponseDTO(
-                    id = follower.id ?: error("Follower id should not be null"),
-                    followerCount = follower.follower,
-                    followingCount = follower.following
+                    id = target.id ?: error("Target id should not be null"),
+                    followerCount = target.follower,
+                    followingCount = target.following
                 )
             }
         }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#9 -> main
- closed #9

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 팔로우하는 사용자 기준이 아닌 팔로잉하는 사용자의 팔로워, 팔로잉 수 반환하도록 수정했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
